### PR TITLE
Modify: 잘못된 경보에러 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "react-images-uploading": "^3.1.6",
     "react-redux": "^8.0.1",
     "react-router-dom": "^6.3.0",
-    "react-scripts": "5.0.1",
     "redux": "^4.2.0",
     "stream": "^0.0.2",
     "stream-chat": "^6.5.1",
@@ -49,6 +48,7 @@
     "@testing-library/react": "^12.1.2",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "prettier": "^2.6.2"
+    "prettier": "^2.6.2",
+    "react-scripts": "5.0.1"
   }
 }


### PR DESCRIPTION
npm에서 잡히는 취약경보 에러가 잘못된 정보에 의해서 발생하는 것임을 알게 됐음.

package.json에 react-script를 devDependencies로 옮겨줌으로써 해결할 수 있었음.
